### PR TITLE
Add SUSE/spacewalk to the source repo list

### DIFF
--- a/SUSE/open_prs.py
+++ b/SUSE/open_prs.py
@@ -29,6 +29,7 @@ repos = (
     "openSUSE/salt",
     "cobbler/cobbler",
     "uyuni-project/uyuni",
+    "SUSE/spacewalk",
 )
 
 class bcolors:


### PR DESCRIPTION
As per this is a SUSE specific tool and we are injecting the `GITHUB_TOKEN_GALAXY`, I think there is no harm in having a *closed* repo as the `SUSE/spacewalk` one.