### PR TITLE
Now reads settings from TOML file and adds requirements file

### DIFF
--- a/SUSE/open_prs/open_prs.toml
+++ b/SUSE/open_prs/open_prs.toml
@@ -1,0 +1,20 @@
+# Please provide the github usernames here.
+usernames = [
+    "brejoc",
+    "dincamihai",
+    "meaksh",
+]
+
+# The repository name with owner: brejoc/my_repo
+repos = [
+    "saltstack/salt",
+    "openSUSE/salt",
+    "SUSE/spacewalk",
+    "cobbler/cobbler",
+    "uyuni-project/uyuni",
+]
+
+# The Github API token can either be provided here or via the environment
+# variable `GITHUB_API_TOKEN`. This setting has precedence over the
+# environment variable.
+# github_token = "<insert_github_api_token_here>"

--- a/SUSE/open_prs/requirements.txt
+++ b/SUSE/open_prs/requirements.txt
@@ -1,0 +1,3 @@
+toml
+requests
+python-dateutil


### PR DESCRIPTION
* usernames and repos now can be provided with a TOML settings file. This also true for the Github API token. But this can also still be provided via a environment variable.
* Requirements can be installed with the new requirements.txt.